### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This custom navigation controller supports storyboard, including push and pop se
 - [CocoaPods](http://cocoapods.org) is the recommended way to add HMGLNavigationController to your project.
 - If you prefer, you can simply [download HMGLNavigationController](https://github.com/alexandreos/HMGLNavigationController/zipball/master) and add the files from the HMGLNavigationController folder to your project. This repository also includes a demo project.
 
-### Cocoapods
+### CocoaPods
 
 1. Add a pod entry for HMGLNavigationController to your Podfile `pod 'HMGLNavigationController', '~> 0.0.1'`
 2. Install the pod(s) by running `pod install`.


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
